### PR TITLE
Fixes deprecated syscall issue on macOS 10.12 [#23](https://github.com/mfreiholz/humblelogging/issues/23)

### DIFF
--- a/include/humblelogging/logevent.h
+++ b/include/humblelogging/logevent.h
@@ -20,7 +20,7 @@ public:
 	const std::string& getFunction() const { return _function; }
 	const time_t& getTime() const { return _time; }
 	unsigned int getPid() const { return _pid; }
-	unsigned int getTid() const { return _tid; }
+	size_t getTid() const { return _tid; }
 
 private:
 	int _level;
@@ -30,7 +30,7 @@ private:
 	std::string _function;
 	time_t _time;
 	unsigned int _pid;
-	unsigned int _tid;
+	size_t _tid;
 };
 
 HL_NAMESPACE_END

--- a/include/humblelogging/util/processinfo.h
+++ b/include/humblelogging/util/processinfo.h
@@ -2,6 +2,7 @@
 #define HL_PROCESSINFO_H
 
 #include "humblelogging/defines.h"
+#include <cstddef>
 
 HL_NAMESPACE_BEGIN
 
@@ -9,7 +10,7 @@ class HUMBLE_EXPORT_API ProcessInfo
 {
 public:
 	static unsigned int getProcessID();
-	static unsigned int getThreadID();
+	static size_t getThreadID();
 };
 
 HL_NAMESPACE_END

--- a/src/formatter/patternformatter.cpp
+++ b/src/formatter/patternformatter.cpp
@@ -1,6 +1,7 @@
 #include "humblelogging/formatter/patternformatter.h"
 
 #include <cstdio>
+#include <inttypes.h>
 #include <sstream>
 
 #include "humblelogging/logevent.h"
@@ -59,8 +60,9 @@ std::string PatternFormatter::format(const LogEvent& logEvent) const
 	if ((pos = s.find("%tid")) != std::string::npos)
 	{
 		char buff[10];
-		sprintf(buff, "%d", logEvent.getTid());
-		s.replace(pos, 4, buff);
+		auto value = logEvent.getTid();
+		sprintf(buff, "%zu", value);
+		s.replace(pos, sizeof(value), buff);
 	}
 	if ((pos = s.find("%filename")) != std::string::npos)
 	{

--- a/src/util/processinfo.cpp
+++ b/src/util/processinfo.cpp
@@ -7,6 +7,7 @@
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <pthread.h>
 #endif
 
 HL_NAMESPACE_BEGIN
@@ -20,10 +21,14 @@ unsigned int ProcessInfo::getProcessID()
 #endif
 }
 
-unsigned int ProcessInfo::getThreadID()
+size_t ProcessInfo::getThreadID()
 {
 #ifdef _WIN32
 	return GetCurrentThreadId();
+#elif defined(__APPLE__) && defined(__MACH__)
+    uint64_t tid64;
+    pthread_threadid_np(nullptr, &tid64);
+    return static_cast<size_t>(tid64);
 #else
 	return syscall(SYS_gettid); //return gettid();
 #endif


### PR DESCRIPTION
…m/mfreiholz/humblelogging/issues/23)

* Visual Studio 2015 adds support for %zu (see change in src/formatter/patternformatter.cpp)
* I recommend storing the ThreadID as size_t or an equivalent since that appears to be the popular approach